### PR TITLE
contains() のリネームに共なう修正

### DIFF
--- a/lib/unicode-util.coffee
+++ b/lib/unicode-util.coffee
@@ -15,6 +15,11 @@ class UnicodeUtil
 
   @getRangeListByName: (name) ->
     rangeList = new Array()
+    if !String::includes
+      # console.log("String::includes is undefined")
+      String::includes = ->
+        'use strict'
+        String::indexOf.apply(this, arguments) != -1
     for block in @unicode
       if block[1].includes(name)
         rangeList = rangeList.concat([block[0]])

--- a/lib/unicode-util.coffee
+++ b/lib/unicode-util.coffee
@@ -16,7 +16,7 @@ class UnicodeUtil
   @getRangeListByName: (name) ->
     rangeList = new Array()
     for block in @unicode
-      if block[1].contains(name)
+      if block[1].includes(name)
         rangeList = rangeList.concat([block[0]])
     return rangeList
 


### PR DESCRIPTION
はじめまして。こちらのパッケージをとても頼りにつかわせていただいております。

Git HEADのAtomにて、下記のエラーによりactivateに失敗していたので、修正してみました。

**Atom Version**: 0.189.0-dd271aa
**System**: Mac OS X 10.10.2
**Thrown From**: [japanese-wrap](https://github.com/raccy/japanese-wrap) package, v0.2.4

### Stack Trace

Failed to activate the japanese-wrap package

```
At undefined is not a function

TypeError: undefined is not a function
    at Function.module.exports.UnicodeUtil.getRangeListByName (/Users/tomoya/src/github.com/tomoya/dotfiles/.atom/packages/japanese-wrap/lib/unicode-util.coffee:43:22)
（以下略）
```

原因は、こちらのコミットによってChrome41になったことから、String.prototype.contains() メソッドがリネームされ、String.prototype.includes() に置き換わったことに由来するようです

* https://github.com/atom/atom/commit/dd271aae960039b35ce20e2ecfcfc5bc751b42da
* 参考 [String.prototype.includes() - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes)

下方互換性のため、MDNドキュメントを参考に未定義の場合の処理も含めてみましたが、特に不要であれば削除下さい。
